### PR TITLE
Fix broken menu items due to Package Control install directory

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -24,7 +24,7 @@
                             {
                                 "command": "open_file", "args":
                                 {
-                                    "file": "${packages}/SublimePrint/README.md"
+                                    "file": "${packages}/Simple Print Function/README.md"
                                 },
                                 "caption": "README"
                             },
@@ -32,7 +32,7 @@
                             {
                                 "command": "open_file", "args":
                                 {
-                                    "file": "${packages}/SublimePrint/SublimePrint.sublime-settings"
+                                    "file": "${packages}/Simple Print Function/SublimePrint.sublime-settings"
                                 },
                                 "caption": "Settings – Default"
                             },


### PR DESCRIPTION
The default Package Control channel listing for this package uses the name "Simple Print Function". _(I assume it was changed due to their don't-use-"sublime"-in-names policy?)_

Unfortunately that means it installs  to ${packages}/Simple Print Function/, breaking the menu links to the readme and default settings.

I don't know if there's a way to set a different installation directory, or if you are going to keep the twin naming conventions, but as a temporary solution I updated the menu settings.
